### PR TITLE
Feat: Export modules from winston

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,21 @@ async function bootstrap() {
 bootstrap();
 ```
 
+## Using methods from winston
+
+Just destructure the necessary methods directly from traceability
+
+```js
+import traceability from 'traceability';
+
+const {
+  format,
+  addColors,
+} = traceability;
+
+```
+
+``format`` and ``addColors`` comes from winston
 # Known issues
 
  ## TypeError: async_hooks_1.AsyncLocalStorage is not a constructor:

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "prepare": "yarn lint ; yarn build ",
     "test": "jest --runInBand --detectOpenHandles --no-cache ---coverage",
     "lint": "eslint . --ext .ts,.tsx",
-    "example:express": "yarn ts-node src/examples/express.ts"
+    "example:express": "yarn ts-node src/examples/express.ts",
+    "example:express-personalized": "yarn ts-node src/examples/express-with-config.ts"
   }
 }

--- a/src/examples/express-with-config.ts
+++ b/src/examples/express-with-config.ts
@@ -1,0 +1,48 @@
+import express from 'express';
+import { ETrackKey } from '../ContextAsyncHooks';
+import traceability from '../index';
+
+const {
+  ContextAsyncHooks,
+  Logger,
+  LoggerTraceability,
+  format,
+  addColors,
+} = traceability;
+
+const colors = {
+  info: 'green',
+  warn: 'yellow',
+  error: 'red',
+};
+const colorizer = format.colorize();
+addColors(colors);
+
+const conf = LoggerTraceability.getLoggerOptions();
+const formated = format.combine(
+  format.timestamp(),
+  format.simple(),
+  format.printf(
+    msg =>
+      `${colorizer.colorize(msg.level, `${msg.timestamp} - ${msg.level}:`)} ${
+        msg.message
+      }`,
+  ),
+);
+conf.format = formated;
+LoggerTraceability.configure(conf);
+
+const app = express();
+const port = 3000;
+ContextAsyncHooks.trackKey = ETrackKey['X-Correlation-ID'];
+app.use(ContextAsyncHooks.getExpressMiddlewareTracking());
+app.get('/', (req, res) => {
+  res.send('Hello World!');
+});
+
+app.listen(port, () => {
+  // Logger.info(`Example app listening at http://localhost:${port}`);
+  Logger.info('This is the logger info!');
+  Logger.error('This is the logger error!');
+  Logger.warn('This is the logger warn!');
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
+import winston from 'winston';
 import ContextAsyncHooks, { ETrackKey } from './ContextAsyncHooks';
 import Logger, { LoggerTraceability } from './LoggerTraceability';
 
 export default {
+  ...winston,
   ContextAsyncHooks,
   LoggerTraceability,
   Logger,


### PR DESCRIPTION
On this PR was added a export modules from winston by traceability.

This is necessary to allow of users of traceability don't import directly the winston lib on his projects to do some configuration in traceability.

Before this PR is necessary import this for to do some configuration

```
import { format, addColors } from 'winston';
import traceability from 'traceability';
```


After this PR


```
import traceability from 'traceability';

const {
  ContextAsyncHooks,
  Logger,
  LoggerTraceability,
  format,
  addColors,
} = traceability;
```


And yet is added more usage example from traceability
