### PR TITLE
Break-change: Add barrel export

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,7 @@
     "jest"
   ],
   "rules": {
+    "import/prefer-default-export": "off",
     "prettier/prettier": "error",
     "import/extensions" : [
       "error",

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install traceability
 ## Logging the trackId in all methods
 > **File:** index.js
 ```js
-import traceability from 'traceability'
+import * as traceability from 'traceability'
 
 
 const levelRoot = () =>{
@@ -58,9 +58,8 @@ levelRoot();
 
 ## Changing the wiston configuration
 ```js
-import traceability from 'traceability';
+import { ContextAsyncHooks, Logger, LoggerTraceability } from 'traceability';
 
-const { ContextAsyncHooks, Logger, LoggerTraceability } = traceability;
 
 const conf = LoggerTraceability.getLoggerOptions();
 conf.silent = true;
@@ -74,9 +73,8 @@ Logger.info('levelRoot');
 > **File** express.js (see examples directory)
 ```js
 import express from 'express';
-import traceability from 'traceability';
+import { ContextAsyncHooks, Logger } from 'traceability';
 
-const { ContextAsyncHooks, Logger } = traceability;
 
 const app = express();
 const port = 3000;
@@ -161,16 +159,12 @@ bootstrap();
 Just destructure the necessary methods directly from traceability
 
 ```js
-import traceability from 'traceability';
-
-const {
-  format,
-  addColors,
-} = traceability;
+import {format, addColors} from 'traceability';
 
 ```
 
 ``format`` and ``addColors`` comes from winston
+
 # Known issues
 
  ## TypeError: async_hooks_1.AsyncLocalStorage is not a constructor:

--- a/README.md
+++ b/README.md
@@ -156,6 +156,21 @@ async function bootstrap() {
 bootstrap();
 ```
 
+## Using methods from winston
+
+Just destructure the necessary methods directly from traceability
+
+```js
+import traceability from 'traceability';
+
+const {
+  format,
+  addColors,
+} = traceability;
+
+```
+
+``format`` and ``addColors`` comes from winston
 # Known issues
 
  ## TypeError: async_hooks_1.AsyncLocalStorage is not a constructor:

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "prepare": "yarn lint ; yarn build ",
     "test": "jest --runInBand --detectOpenHandles --no-cache ---coverage",
     "lint": "eslint . --ext .ts,.tsx",
-    "example:express": "yarn ts-node src/examples/express.ts"
+    "example:express": "yarn ts-node src/examples/express.ts",
+    "example:express-personalized": "yarn ts-node src/examples/express-with-config.ts"
   }
 }

--- a/src/ContextAsyncHooks.ts
+++ b/src/ContextAsyncHooks.ts
@@ -15,8 +15,8 @@ export enum ETrackKey {
   'X-Correlation-ID' = 'X-Correlation-ID',
   'trackId' = 'trackId',
 }
-export class ContextAsyncHooks {
-  private static instance: ContextAsyncHooks;
+class ContextAsyncHooksClass {
+  private static instance: ContextAsyncHooksClass;
 
   public asyncLocalStorage: AsyncLocalStorage<any>;
 
@@ -58,12 +58,12 @@ export class ContextAsyncHooks {
     return this.asyncLocalStorage.getStore();
   }
 
-  public static getInstance(): ContextAsyncHooks {
-    if (!ContextAsyncHooks.instance) {
-      ContextAsyncHooks.instance = new ContextAsyncHooks();
+  public static getInstance(): ContextAsyncHooksClass {
+    if (!ContextAsyncHooksClass.instance) {
+      ContextAsyncHooksClass.instance = new ContextAsyncHooksClass();
     }
-    return ContextAsyncHooks.instance;
+    return ContextAsyncHooksClass.instance;
   }
 }
 
-export default ContextAsyncHooks.getInstance();
+export const ContextAsyncHooks = ContextAsyncHooksClass.getInstance();

--- a/src/LoggerTraceability.ts
+++ b/src/LoggerTraceability.ts
@@ -1,15 +1,15 @@
 /* eslint-disable class-methods-use-this */
 /* eslint-disable no-param-reassign */
+import { Logger } from 'winston';
+
+import { TransformableInfo } from 'logform';
 import {
   createLogger,
   format,
-  Logger,
+  ContextAsyncHooks,
   LoggerOptions,
   transports,
-} from 'winston';
-
-import { TransformableInfo } from 'logform';
-import ContextAsyncHooks from './ContextAsyncHooks';
+} from './index';
 
 export class LoggerTraceability {
   private static instance: LoggerTraceability;
@@ -53,5 +53,3 @@ export class LoggerTraceability {
     return this.logger;
   }
 }
-
-export default LoggerTraceability.getInstance().getLogger();

--- a/src/__test__/ContextAsyncHooks.test.ts
+++ b/src/__test__/ContextAsyncHooks.test.ts
@@ -1,8 +1,6 @@
 /* eslint-disable no-console */
 
-import traceability from '../index';
-
-const { Logger, ContextAsyncHooks } = traceability;
+import { Logger, ContextAsyncHooks } from '../index';
 
 describe('AsyncHooks Context', () => {
   ContextAsyncHooks.setContext({ trackId: '1234567890', parent: 'alm' });

--- a/src/__test__/LoggerTraceability.test.ts
+++ b/src/__test__/LoggerTraceability.test.ts
@@ -1,4 +1,4 @@
-import Logger, { LoggerTraceability } from '../LoggerTraceability';
+import { Logger, LoggerTraceability } from '../index';
 
 describe('LoggerTraceability', () => {
   it('Should update a LoggerOptions', () => {

--- a/src/examples/express-with-config.ts
+++ b/src/examples/express-with-config.ts
@@ -1,0 +1,48 @@
+import express from 'express';
+import { ETrackKey } from '../ContextAsyncHooks';
+import traceability from '../index';
+
+const {
+  ContextAsyncHooks,
+  Logger,
+  LoggerTraceability,
+  format,
+  addColors,
+} = traceability;
+
+const colors = {
+  info: 'green',
+  warn: 'yellow',
+  error: 'red',
+};
+const colorizer = format.colorize();
+addColors(colors);
+
+const conf = LoggerTraceability.getLoggerOptions();
+const formated = format.combine(
+  format.timestamp(),
+  format.simple(),
+  format.printf(
+    msg =>
+      `${colorizer.colorize(msg.level, `${msg.timestamp} - ${msg.level}:`)} ${
+        msg.message
+      }`,
+  ),
+);
+conf.format = formated;
+LoggerTraceability.configure(conf);
+
+const app = express();
+const port = 3000;
+ContextAsyncHooks.trackKey = ETrackKey['X-Correlation-ID'];
+app.use(ContextAsyncHooks.getExpressMiddlewareTracking());
+app.get('/', (req, res) => {
+  res.send('Hello World!');
+});
+
+app.listen(port, () => {
+  // Logger.info(`Example app listening at http://localhost:${port}`);
+  Logger.info('This is the logger info!');
+  Logger.error('This is the logger error!');
+  Logger.warn('This is the logger warn!');
+});

--- a/src/examples/express-with-config.ts
+++ b/src/examples/express-with-config.ts
@@ -1,14 +1,12 @@
 import express from 'express';
-import { ETrackKey } from '../ContextAsyncHooks';
-import traceability from '../index';
-
-const {
-  ContextAsyncHooks,
+import {
   Logger,
+  ContextAsyncHooks,
   LoggerTraceability,
   format,
   addColors,
-} = traceability;
+  ETrackKey,
+} from '../index';
 
 const colors = {
   info: 'green',

--- a/src/examples/express.ts
+++ b/src/examples/express.ts
@@ -1,8 +1,5 @@
 import express from 'express';
-import { ETrackKey } from '../ContextAsyncHooks';
-import traceability from '../index';
-
-const { ContextAsyncHooks, Logger } = traceability;
+import { ContextAsyncHooks, Logger, ETrackKey } from '../index';
 
 const app = express();
 const port = 3000;

--- a/src/examples/levels.ts
+++ b/src/examples/levels.ts
@@ -1,19 +1,19 @@
 import { ETrackKey } from '../ContextAsyncHooks';
-import traceability from '../index';
+import { Logger, ContextAsyncHooks } from '../index';
 
 export const level2 = (): void => {
-  traceability.Logger.info('level2');
+  Logger.info('level2');
 };
 
 export const level1 = (): void => {
-  traceability.Logger.info('level1');
+  Logger.info('level1');
   level2();
 };
 
 export const levelRoot = (): void => {
-  traceability.ContextAsyncHooks.trackKey = ETrackKey['X-Correlation-ID'];
-  const context = traceability.ContextAsyncHooks.getTrackId({});
-  traceability.ContextAsyncHooks.setContext(context);
-  traceability.Logger.info('levelRoot');
+  ContextAsyncHooks.trackKey = ETrackKey['X-Correlation-ID'];
+  const context = ContextAsyncHooks.getTrackId({});
+  ContextAsyncHooks.setContext(context);
+  Logger.info('levelRoot');
   level1();
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
+import winston from 'winston';
 import ContextAsyncHooks, { ETrackKey } from './ContextAsyncHooks';
 import Logger, { LoggerTraceability } from './LoggerTraceability';
 
 export default {
+  ...winston,
   ContextAsyncHooks,
   LoggerTraceability,
   Logger,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,54 @@
-import winston from 'winston';
-import ContextAsyncHooks, { ETrackKey } from './ContextAsyncHooks';
-import Logger, { LoggerTraceability } from './LoggerTraceability';
+import {
+  addColors,
+  format,
+  Logform,
+  config,
+  transports,
+  transport,
+  ExceptionHandler,
+  QueryOptions,
+  Profiler,
+  LogEntry,
+  LogMethod,
+  LeveledLogMethod,
+  LoggerOptions,
+  Container,
+  error,
+  warn,
+  info,
+  http,
+  verbose,
+  debug,
+  silly,
+  createLogger,
+} from 'winston';
+import { LoggerTraceability } from './LoggerTraceability';
 
-export default {
-  ...winston,
-  ContextAsyncHooks,
-  LoggerTraceability,
-  Logger,
-  ETrackKey,
+export * from './ContextAsyncHooks';
+export * from './LoggerTraceability';
+export const Logger = LoggerTraceability.getInstance().getLogger();
+
+export {
+  createLogger,
+  addColors,
+  format,
+  QueryOptions,
+  Logform,
+  config,
+  transports,
+  transport,
+  ExceptionHandler,
+  Profiler,
+  LogEntry,
+  LogMethod,
+  LeveledLogMethod,
+  LoggerOptions,
+  Container,
+  error,
+  warn,
+  info,
+  http,
+  verbose,
+  debug,
+  silly,
 };


### PR DESCRIPTION
This PR will causa an break-change.

Before this PR we needed import all files from traceability and after destructure wich we really need.

After this PR, this way to import doesn't  allowed. We need import from barrel.

before 

```
import traceability from 'traceability';

const { ContextAsyncHooks, Logger, LoggerTraceability } = traceability;

```

after

```
import  { ContextAsyncHooks, Logger, LoggerTraceability }  from 'traceability';

or

import * as traceability from 'traceability';
```

