### PR TITLE
Update Correlation ID Format and Enable traceparent Context Propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,34 @@ app.listen(port, () => {
 });
 ```
 
+
+## Using as a Express middleware with traceparent propagator
+> **File** express-traceparent.ts (see examples directory)
+```js
+import express from 'express';
+import { ContextAsyncHooks, Logger } from 'traceability';
+
+
+const app = express();
+const port = 3000;
+
+ContextAsyncHooks.trackKey= ETrackKey['cid']
+
+app.use(ContextAsyncHooks.getExpressMiddlewareTracking({
+  responseHeaderPropagator: 'traceparent'
+}));
+app.get('/', (req, res) => {
+  Logger.info('Hello World with trackId on server side!');
+  res.send('Hello World!');
+});
+
+app.listen(port, () => {
+  Logger.info(`Example app listening at http://localhost:${port}`);
+});
+```
+> When traceparent is enabled, the library will automatically generate and propagate the traceparent header in all outgoing requests, following the W3C Trace Context format:
+`traceparent: 00-<trace-id>-<span-id>-<trace-flags>`
+
 ### Running the code:
 ```
 yarn ts-node ./express.ts

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "test": "jest --runInBand --detectOpenHandles --no-cache ---coverage",
     "lint": "eslint . --ext .ts,.tsx",
     "example:express": "DEBUG=express:*  yarn ts-node src/examples/express.ts",
+    "example:express-traceparent": "DEBUG=express:*  yarn ts-node src/examples/express-traceparent.ts",
     "example:express-personalized": "yarn ts-node src/examples/express-with-config.ts"
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@types/node": "^13.13.2",
     "express": "^4.17.1",
     "logform": "^2.2.0",
-    "uuid": "^8.3.2",
     "winston": "^3.3.3"
   },
   "scripts": {

--- a/src/ContextAsyncHooks.ts
+++ b/src/ContextAsyncHooks.ts
@@ -58,6 +58,11 @@ class ContextAsyncHooksClass {
     return { cid: RandomIdGenerator.generateTraceId() };
   }
 
+  public getTraceParent(): string {
+    const { cid } = this.getTrackId();
+    return this.buildTraceParent(cid as string);
+  }
+
   private getTraceIdFromTraceParent(traceParent: string): string {
     const traceId = traceParent.split('-')[1];
 

--- a/src/ContextAsyncHooks.ts
+++ b/src/ContextAsyncHooks.ts
@@ -3,8 +3,8 @@
 /* eslint-disable no-console */
 /* eslint-disable class-methods-use-this */
 import { NextFunction, Request, Response } from 'express';
-import { v4 } from 'uuid';
 import { AsyncLocalStorage } from 'async_hooks';
+import { RandomIdGenerator } from './idGenerator';
 
 export interface RequestContext {
   [key: string]: string | string[] | undefined;
@@ -39,7 +39,7 @@ class ContextAsyncHooksClass {
     if (context && context.cid) {
       return { cid: context.cid };
     }
-    return { cid: v4() };
+    return { cid: RandomIdGenerator.generateTraceId() };
   }
 
   public getContext(): RequestContext | undefined {

--- a/src/ContextAsyncHooks.ts
+++ b/src/ContextAsyncHooks.ts
@@ -18,12 +18,21 @@ class ContextAsyncHooksClass {
     this.asyncLocalStorage = new AsyncLocalStorage<any>();
   }
 
-  public getExpressMiddlewareTracking(): any {
+  public getExpressMiddlewareTracking(config?: {
+    responseHeaderPropagator?: 'cid' | 'traceparent';
+  }): any {
     return (request: Request, response: Response, next: NextFunction): void => {
       const { cid } = this.getTrackId(request.headers);
       this.setContext({ cid });
-      response.setHeader('cid', cid as string);
-      next();
+      if (!config || config.responseHeaderPropagator === 'cid') {
+        response.setHeader('cid', cid as string);
+        next();
+      }
+      if (config?.responseHeaderPropagator === 'traceparent') {
+        const traceparent = this.buildTraceParent(cid as string);
+        response.setHeader('traceparent', traceparent);
+        next();
+      }
     };
   }
 
@@ -39,7 +48,25 @@ class ContextAsyncHooksClass {
     if (context && context.cid) {
       return { cid: context.cid };
     }
+    if (
+      context &&
+      context.traceparent &&
+      typeof context.traceparent === 'string'
+    ) {
+      return { cid: this.getTraceIdFromTraceParent(context.traceparent) };
+    }
     return { cid: RandomIdGenerator.generateTraceId() };
+  }
+
+  private getTraceIdFromTraceParent(traceParent: string): string {
+    const traceId = traceParent.split('-')[1];
+
+    return traceId;
+  }
+
+  private buildTraceParent(traceId: string): string {
+    const spanId = RandomIdGenerator.generateSpanId();
+    return `00-${traceId}-${spanId}-01`;
   }
 
   public getContext(): RequestContext | undefined {

--- a/src/examples/express-traceparent.ts
+++ b/src/examples/express-traceparent.ts
@@ -1,0 +1,19 @@
+import express from 'express';
+import { ContextAsyncHooks, Logger } from '../index';
+
+const app = express();
+const port = 3000;
+
+app.use(
+  ContextAsyncHooks.getExpressMiddlewareTracking({
+    responseHeaderPropagator: 'traceparent',
+  }),
+);
+app.get('/', (req, res) => {
+  Logger.info('Hello World with trackId on server side!');
+  res.send('Hello World!');
+});
+
+app.listen(port, () => {
+  Logger.info(`Example app listening at http://localhost:${port}`);
+});

--- a/src/idGenerator.ts
+++ b/src/idGenerator.ts
@@ -1,0 +1,39 @@
+/* eslint-disable no-bitwise */
+/* eslint-disable no-plusplus */
+const SPAN_ID_BYTES = 8;
+const TRACE_ID_BYTES = 16;
+
+const SHARED_BUFFER = Buffer.allocUnsafe(TRACE_ID_BYTES);
+function getIdGenerator(bytes: number): () => string {
+  return function generateId(): string {
+    for (let i = 0; i < bytes / 4; i++) {
+      // unsigned right shift drops decimal part of the number
+      // it is required because if a number between 2**32 and 2**32 - 1 is generated, an out of range error is thrown by writeUInt32BE
+      SHARED_BUFFER.writeUInt32BE((Math.random() * 2 ** 32) >>> 0, i * 4);
+    }
+
+    // If buffer is all 0, set the last byte to 1 to guarantee a valid w3c id is generated
+    for (let i = 0; i < bytes; i++) {
+      if (SHARED_BUFFER[i] > 0) {
+        break;
+      } else if (i === bytes - 1) {
+        SHARED_BUFFER[bytes - 1] = 1;
+      }
+    }
+
+    return SHARED_BUFFER.toString('hex', 0, bytes);
+  };
+}
+export class RandomIdGenerator {
+  /**
+   * Returns a random 16-byte trace ID formatted/encoded as a 32 lowercase hex
+   * characters corresponding to 128 bits.
+   */
+  static generateTraceId = getIdGenerator(TRACE_ID_BYTES);
+
+  /**
+   * Returns a random 8-byte span ID formatted/encoded as a 16 lowercase hex
+   * characters corresponding to 64 bits.
+   */
+  static generateSpanId = getIdGenerator(SPAN_ID_BYTES);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1142,9 +1142,9 @@
   integrity sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA==
 
 "@types/node@^13.13.2":
-  version "13.13.48"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.48.tgz#46a3df718aed5217277f2395a682e055a487e341"
-  integrity sha512-z8wvSsgWQzkr4sVuMEEOvwMdOQjiRY2Y/ZW4fDfjfe3+TfQrZqFKOthBgk2RnVEmtOKrkwdZ7uTvsxTBLjKGDQ==
+  version "13.13.52"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.52.tgz#03c13be70b9031baaed79481c0c0cfb0045e53f7"
+  integrity sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -7796,7 +7796,7 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0, uuid@^8.3.2:
+uuid@^8.3.0:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
This pull request introduces several improvements to enhance context propagation and traceability within the application. Key changes include updating the correlation ID format (32 lowercase hex without dash), adding support for the traceparent header, and enabling clients to access the traceparent as part of context propagation.

All updates have been tested to ensure backward compatibility and that the traceparent header propagates correctly in supported environments. Any feedback or additional testing recommendations are welcome.