### PR TITLE
Fix logger configuration to keep transports

### DIFF
--- a/src/LoggerTraceability.ts
+++ b/src/LoggerTraceability.ts
@@ -28,7 +28,12 @@ export class LoggerTraceability {
   }
 
   public static configure(options: LoggerOptions): void {
-    LoggerTraceability.getInstance().getLogger().configure(options);
+    const logger = LoggerTraceability.getInstance().getLogger();
+    const newOptions = { ...options };
+    if (newOptions.transports === undefined) {
+      newOptions.transports = logger.transports;
+    }
+    logger.configure(newOptions);
   }
 
   public static getLoggerOptions(): LoggerOptions {

--- a/src/__test__/LoggerTraceability.test.ts
+++ b/src/__test__/LoggerTraceability.test.ts
@@ -14,4 +14,11 @@ describe('LoggerTraceability', () => {
     expect(Logger.level).toBe('error');
     expect(Logger.silent).toBeTruthy();
   });
+
+  it('should preserve transports if not provided', () => {
+    const initialTransports = Logger.transports.length;
+    LoggerTraceability.configure({ level: 'debug' });
+    expect(Logger.level).toBe('debug');
+    expect(Logger.transports.length).toBe(initialTransports);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure transports aren't cleared when configuring the logger
- add regression test for transport preservation

## Testing
- `npx -y yarn@1 test`

## Why:
Attempt to write logs with no transports, which can increase memory usage...

------
https://chatgpt.com/codex/tasks/task_e_686313fd0654832d831d1fe73233843a